### PR TITLE
Fix example function errors

### DIFF
--- a/A3AE/addons/functions/Events/fn_addExampleEventListener.sqf
+++ b/A3AE/addons/functions/Events/fn_addExampleEventListener.sqf
@@ -2,4 +2,4 @@ if !(isClass (missionConfigFile/"A3A")) exitWith {};//safeguard to block running
 
 //see (configFile/"A3A"/"Events") for a list of available events
 //arguments are: Event type, Event Unique ID, function
-["AIVehInit", "A3A_Events_example", A3AE_functions_fnc_AIVehInit] call A3A_Events_fnc_addEventListener;
+["AIVehInit", "A3A_Events_example", A3A_functions_fnc_AIVehInit] call A3A_Events_fnc_addEventListener;


### PR DESCRIPTION
I've made a small change - A3AE -> A3A
Feel free to test my change yourself.

Current function examples cause errors.

```20:38:25 Error in expression <



["AIVehInit", "A3A_Events_example", A3AE_functions_fnc_AIVehInit] call A3A_E>
20:38:25   Error position: <A3AE_functions_fnc_AIVehInit] call A3A_E>
20:38:25   Error Undefined variable in expression: a3ae_functions_fnc_aivehinit
20:38:25 File \x\a3ae_rhs_napa_su25\addons\functions\Events\fn_addExampleEventListener.sqf [a3ae_rhs_napa_su25_functions_fnc_addExampleEventListener]..., line 5
20:38:25  ➥ Context:     [] L586 (A3\functions_f\initFunctions.sqf)
    [] L638 (A3\functions_f\initFunctions.sqf)
    [] L637 (A3\functions_f\initFunctions.sqf)
    [] L632 (A3\functions_f\initFunctions.sqf)
    [] L634 (A3\functions_f\initFunctions.sqf)
    [] L22 (x\A3A\addons\core\functions\debug\fn_runPostInitFuncs.sqf)
    [] L22 (x\A3A\addons\core\functions\debug\fn_runPostInitFuncs.sqf)
    [] L5 (\x\a3ae_rhs_napa_su25\addons\functions\Events\fn_addExampleEventListener.sqf [a3ae_rhs_napa_su25_functions_fnc_addExampleEventListener])
    [] L31 (x\A3A\addons\events\functions\fn_addEventListener.sqf)
    [] L32 (x\A3A\addons\events\functions\fn_addEventListener.sqf)
    [] L32 (x\A3A\addons\events\functions\fn_addEventListener.sqf)
    [] L32 (x\A3A\addons\events\functions\fn_addEventListener.sqf)

20:38:25 2024-12-11 18:38:25:840 | Antistasi | Error | File: A3A_events_fnc_addEventListener | Invalid params passed: ["AIVehInit","A3A_Events_example",any] | Called By: a3ae_rhs_napa_su25_functions_fnc_addExampleEventListener
20:38:25 Unknown entity: '& b'
20:38:25  ➥ Context:     [] L119 (DBUG\functions\console\fn_initCommands.sqf)
    [] L105 (DBUG\functions\console\fn_initCommands.sqf)
    [] L69 (DBUG\functions\console\fn_initCommands.sqf)
    [] L71 (DBUG\functions\console\fn_initCommands.sqf)
 <-     [] L586 (A3\functions_f\initFunctions.sqf)
    [] L638 (A3\functions_f\initFunctions.sqf)
    [] L637 (A3\functions_f\initFunctions.sqf)
    [] L632 (A3\functions_f\initFunctions.sqf)
    [] L634 (A3\functions_f\initFunctions.sqf)
    [] L13 (/DEV_TOOLS/functions/general/fn_postInit.sqf)
    [] L14 (/DEV_TOOLS/functions/general/fn_postInit.sqf)
    [] L5 (DBUG\functions\console\fn_initCommands.sqf)```



